### PR TITLE
remove full path from --provides flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN cd /usr/share/kakadu && sed -i '/#C_OPT += -DKDU_NO_SSSE3/ s/^#//' */make/Ma
 # Compile Kakadu
 RUN cd /usr/share/kakadu/make; export JAVA_HOME=/usr/lib/jvm/java; make -f Makefile-${ARCHITECTURE}-gcc
 # Package Kakadu
-RUN /bin/bash -l -c "fpm -s dir -t rpm -n kakadu -v ${KAKADU_PKG_VERSION} -d java-1.7.0-openjdk --provides '/usr/share/kakadu/apps/make/libkdu_v75R.so()(64bit)' --description \"Kakadu SDK with License. Compiled without SSE3 and AVX2, using Java OpenJDK 1.7.0\" /usr/share/kakadu/ /usr/share/java/kdu_jni/"
+RUN /bin/bash -l -c "fpm -s dir -t rpm -n kakadu -v ${KAKADU_PKG_VERSION} -d java-1.7.0-openjdk --provides 'libkdu_v75R.so()(64bit)' --description \"Kakadu SDK with License. Compiled without SSE3 and AVX2, using Java OpenJDK 1.7.0\" /usr/share/kakadu/ /usr/share/java/kdu_jni/"
 
 # Pull IIPSRV
 RUN git clone ${IIPSRV_REPO} /root/iipsrv-iipsrv-1.0 && cd /root/iipsrv-iipsrv-1.0 && git checkout ${IIPSRV_COMMIT}


### PR DESCRIPTION
This PR does no longer provide a full path for the libkdu_v75R.so `--provides` flag as this prevents the dependency to be resolved.

With the full path and `kakadu` installed, `iipsrv` is unable to resolve the dependency. 

```sh
# rpm -i iipsrv-1.0.0-1.0.el7.x86_64.rpm 
error: Failed dependencies:
	libkdu_v75R.so()(64bit) is needed by iipsrv-1.0.0-1.0.el7.x86_64

# rpm -q --whatprovides libkdu_v75R.so
no package provides libkdu_v75R.so
```

I tested ( on CentOS 7 ) with a couple of iterations but the only solution to have the dependency resolved was to remove the full path. This does not alter the ouput of `rpm -q --whatprovides libkdu_v75R.so`, so this might actually be an issue with `fpm`.

In any case this should allow the .rpms to be installed without any adjustments to the Dockerfile.